### PR TITLE
feat: add auto_cleanup_page configuration option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,16 @@
 # Maximum retry attempts for tool calls (default: 3)
 # PAI_BROWSER_USE_MAX_RETRIES=5
 
-# Tool name prefix (default: "browser_use")
+# Tool name prefix (default: None, toolset falls back to "browser_use")
 # PAI_BROWSER_USE_PREFIX=my_browser
 
 # Force create new page instead of reusing existing (default: False)
-# PAI_BROWSER_USE_ALWAYS_USE_NEW_PAGE=true
+# PAI_BROWSER_USE_ALWAYS_USE_NEW_PAGE=false
+
+# Automatically close created page targets on context exit (default: False)
+# When False, created pages remain open after execution, useful for debugging or inspection.
+# Can be combined with always_use_new_page=true to create new pages and automatically clean them up.
+# PAI_BROWSER_USE_AUTO_CLEANUP_PAGE=false
 
 # Log level for pai-browser-use (default: ERROR)
 PAI_BROWSER_USE_LOG_LEVEL=DEBUG

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,11 +133,25 @@ async def tool_function(param: type) -> dict | ToolReturn:
 
 Uses `pydantic-settings`. Priority: Explicit params > Env vars > Defaults
 
+**Available Configuration Options:**
+
+- `max_retries`: Maximum retry attempts for tool calls (default: 3)
+- `prefix`: Tool name prefix (default: None, toolset falls back to "browser_use")
+- `always_use_new_page`: Force create new page instead of reusing existing (default: False)
+- `auto_cleanup_page`: Automatically close created page targets on context exit (default: False). Can be combined with `always_use_new_page=True` to create and auto-cleanup new pages
+
+**Page Cleanup Behavior:**
+
+- When `always_use_new_page=True`: Creates a new page and tracks it for potential cleanup
+- When `always_use_new_page=False` but no existing page is found: Creates a new page and tracks it for potential cleanup
+- When reusing an existing page: No tracking, cleanup is never attempted (preserves existing pages)
+- Cleanup only occurs if `auto_cleanup_page=True` AND the page was created (not reused)
+
 **Adding new config:**
 
-1. Add to `BrowserUseSettings` in `_config.py` with docstring
+1. Add to `BrowserUseSettings` in `_config.py` with docstring and concrete default value (use `bool`, `int`, `str`, not `None`)
 1. Update `.env.example` with detailed comments (this IS the documentation)
-1. Update module to use setting: `param if param is not None else (settings.field if settings.field is not None else default)`
+1. Update module to use setting: `param if param is not None else settings.field`
 1. Add tests
 
 **No separate config docs needed** - `.env.example` is sufficient

--- a/README.md
+++ b/README.md
@@ -82,12 +82,40 @@ You can override environment variables by passing explicit parameters:
 ```python
 toolset = BrowserUseToolset(
     cdp_url="http://localhost:9222/json/version",
-    max_retries=10,           # Override PAI_BROWSER_USE_MAX_RETRIES
-    prefix="custom_browser",   # Override PAI_BROWSER_USE_PREFIX
+    max_retries=10,              # Override PAI_BROWSER_USE_MAX_RETRIES
+    prefix="custom_browser",     # Override PAI_BROWSER_USE_PREFIX
+    always_use_new_page=True,    # Override PAI_BROWSER_USE_ALWAYS_USE_NEW_PAGE
+    auto_cleanup_page=False,     # Override PAI_BROWSER_USE_AUTO_CLEANUP_PAGE
 )
 ```
 
 **Priority**: Explicit parameters > Environment variables > Defaults
+
+### Page Management
+
+- **`always_use_new_page`**: When `True`, creates a new browser page instead of reusing existing ones. Defaults to `False`.
+- **`auto_cleanup_page`**: When `True`, automatically closes created pages on context exit. Defaults to `False`.
+
+**Use Case Examples:**
+
+```python
+# Default behavior: Reuse existing page, no cleanup needed
+toolset = BrowserUseToolset(cdp_url="http://localhost:9222/json/version")
+
+# Create new page but keep it open for debugging/inspection (default when using always_use_new_page)
+toolset = BrowserUseToolset(
+    cdp_url="http://localhost:9222/json/version",
+    always_use_new_page=True,   # Create fresh page
+    # auto_cleanup_page defaults to False - page remains open
+)
+
+# Create new page and automatically clean up (for production/batch processing)
+toolset = BrowserUseToolset(
+    cdp_url="http://localhost:9222/json/version",
+    always_use_new_page=True,   # Create fresh page
+    auto_cleanup_page=True,     # Clean up after execution
+)
+```
 
 ## Logging
 

--- a/pai_browser_use/_config.py
+++ b/pai_browser_use/_config.py
@@ -19,11 +19,18 @@ class BrowserUseSettings(BaseSettings):
         extra="ignore",
     )
 
-    max_retries: int | None = None
-    """Maximum retry attempts for tool calls. Defaults to None (no retry limit set by config)."""
+    max_retries: int = 3
+    """Maximum retry attempts for tool calls. Defaults to 3."""
 
     prefix: str | None = None
-    """Tool name prefix. Defaults to None (will use toolset ID)."""
+    """Tool name prefix. Defaults to None."""
 
-    always_use_new_page: bool | None = None
-    """Force create new page instead of reusing existing. Defaults to None (will use False)."""
+    always_use_new_page: bool = False
+    """Force create new page instead of reusing existing. Defaults to False."""
+
+    auto_cleanup_page: bool = False
+    """Automatically close created page targets on context exit. Defaults to False.
+
+    Can be combined with always_use_new_page=True to create new pages and automatically clean them up.
+    When False (default), created pages remain open after context exit, useful for debugging or inspection.
+    """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,9 +7,10 @@ from pai_browser_use.toolset import BrowserUseToolset
 def test_browser_use_settings_defaults():
     """Test that BrowserUseSettings has correct default values."""
     settings = BrowserUseSettings()
-    assert settings.max_retries is None
+    assert settings.max_retries == 3
     assert settings.prefix is None
-    assert settings.always_use_new_page is None
+    assert settings.always_use_new_page is False
+    assert settings.auto_cleanup_page is False
 
 
 def test_browser_use_settings_from_env(monkeypatch):
@@ -18,11 +19,13 @@ def test_browser_use_settings_from_env(monkeypatch):
     monkeypatch.setenv("PAI_BROWSER_USE_MAX_RETRIES", "5")
     monkeypatch.setenv("PAI_BROWSER_USE_PREFIX", "custom_prefix")
     monkeypatch.setenv("PAI_BROWSER_USE_ALWAYS_USE_NEW_PAGE", "true")
+    monkeypatch.setenv("PAI_BROWSER_USE_AUTO_CLEANUP_PAGE", "false")
 
     settings = BrowserUseSettings()
     assert settings.max_retries == 5
     assert settings.prefix == "custom_prefix"
     assert settings.always_use_new_page is True
+    assert settings.auto_cleanup_page is False
 
 
 def test_browser_use_toolset_uses_settings_defaults():
@@ -31,6 +34,7 @@ def test_browser_use_toolset_uses_settings_defaults():
     assert toolset.max_retries == 3  # Default fallback
     assert toolset.prefix == "browser_use"  # Default to toolset.id
     assert toolset.always_use_new_page is False  # Default fallback
+    assert toolset.auto_cleanup_page is False  # Default is False
 
 
 def test_browser_use_toolset_uses_env_settings(monkeypatch):
@@ -44,6 +48,7 @@ def test_browser_use_toolset_uses_env_settings(monkeypatch):
     assert toolset.max_retries == 10
     assert toolset.prefix == "env_browser"
     assert toolset.always_use_new_page is True
+    assert toolset.auto_cleanup_page is False  # Default is False regardless of always_use_new_page
 
 
 def test_browser_use_toolset_parameters_override_env(monkeypatch):
@@ -52,6 +57,7 @@ def test_browser_use_toolset_parameters_override_env(monkeypatch):
     monkeypatch.setenv("PAI_BROWSER_USE_MAX_RETRIES", "10")
     monkeypatch.setenv("PAI_BROWSER_USE_PREFIX", "env_browser")
     monkeypatch.setenv("PAI_BROWSER_USE_ALWAYS_USE_NEW_PAGE", "true")
+    monkeypatch.setenv("PAI_BROWSER_USE_AUTO_CLEANUP_PAGE", "true")
 
     # Create toolset with explicit parameters
     toolset = BrowserUseToolset(
@@ -59,12 +65,14 @@ def test_browser_use_toolset_parameters_override_env(monkeypatch):
         max_retries=20,
         prefix="param_browser",
         always_use_new_page=False,
+        auto_cleanup_page=False,
     )
 
     # Parameters should override environment variables
     assert toolset.max_retries == 20
     assert toolset.prefix == "param_browser"
     assert toolset.always_use_new_page is False
+    assert toolset.auto_cleanup_page is False
 
 
 def test_browser_use_toolset_partial_parameter_override(monkeypatch):
@@ -73,17 +81,19 @@ def test_browser_use_toolset_partial_parameter_override(monkeypatch):
     monkeypatch.setenv("PAI_BROWSER_USE_MAX_RETRIES", "10")
     monkeypatch.setenv("PAI_BROWSER_USE_PREFIX", "env_browser")
     monkeypatch.setenv("PAI_BROWSER_USE_ALWAYS_USE_NEW_PAGE", "true")
+    monkeypatch.setenv("PAI_BROWSER_USE_AUTO_CLEANUP_PAGE", "false")
 
     # Create toolset with only max_retries parameter
     toolset = BrowserUseToolset(
         cdp_url="http://localhost:9222/json/version",
         max_retries=20,  # Override env
-        # prefix and always_use_new_page will use env values
+        # prefix, always_use_new_page and auto_cleanup_page will use env values
     )
 
     assert toolset.max_retries == 20  # Overridden by parameter
     assert toolset.prefix == "env_browser"  # From environment
     assert toolset.always_use_new_page is True  # From environment
+    assert toolset.auto_cleanup_page is False  # From environment
 
 
 def test_browser_use_settings_env_file_loading(tmp_path, monkeypatch):
@@ -94,6 +104,7 @@ def test_browser_use_settings_env_file_loading(tmp_path, monkeypatch):
         "PAI_BROWSER_USE_MAX_RETRIES=15\n"
         "PAI_BROWSER_USE_PREFIX=file_browser\n"
         "PAI_BROWSER_USE_ALWAYS_USE_NEW_PAGE=false\n"
+        "PAI_BROWSER_USE_AUTO_CLEANUP_PAGE=true\n"
     )
 
     # Change to temp directory to pick up .env file
@@ -103,3 +114,48 @@ def test_browser_use_settings_env_file_loading(tmp_path, monkeypatch):
     assert settings.max_retries == 15
     assert settings.prefix == "file_browser"
     assert settings.always_use_new_page is False
+    assert settings.auto_cleanup_page is True
+
+
+def test_auto_cleanup_page_defaults_to_false():
+    """Test that auto_cleanup_page defaults to False regardless of always_use_new_page."""
+    # When always_use_new_page is True, auto_cleanup_page should still default to False
+    toolset = BrowserUseToolset(
+        cdp_url="http://localhost:9222/json/version",
+        always_use_new_page=True,
+    )
+    assert toolset.auto_cleanup_page is False
+
+    # When always_use_new_page is False, auto_cleanup_page should also default to False
+    toolset = BrowserUseToolset(
+        cdp_url="http://localhost:9222/json/version",
+        always_use_new_page=False,
+    )
+    assert toolset.auto_cleanup_page is False
+
+    # Default behavior without any parameters
+    toolset = BrowserUseToolset(
+        cdp_url="http://localhost:9222/json/version",
+    )
+    assert toolset.auto_cleanup_page is False
+
+
+def test_auto_cleanup_page_can_override_default():
+    """Test that auto_cleanup_page parameter can override the default behavior."""
+    # Explicitly disable auto_cleanup even when always_use_new_page is True
+    toolset = BrowserUseToolset(
+        cdp_url="http://localhost:9222/json/version",
+        always_use_new_page=True,
+        auto_cleanup_page=False,
+    )
+    assert toolset.always_use_new_page is True
+    assert toolset.auto_cleanup_page is False
+
+    # Explicitly enable auto_cleanup even when always_use_new_page is False
+    toolset = BrowserUseToolset(
+        cdp_url="http://localhost:9222/json/version",
+        always_use_new_page=False,
+        auto_cleanup_page=True,
+    )
+    assert toolset.always_use_new_page is False
+    assert toolset.auto_cleanup_page is True


### PR DESCRIPTION
Adds auto_cleanup_page config to control whether created page targets are automatically closed on context exit. Defaults to False, allowing pages to remain open for debugging/inspection.

- Add auto_cleanup_page setting to BrowserUseSettings with default False
- Update BrowserUseToolset to respect auto_cleanup_page setting
- Simplify configuration fallback logic (settings now have concrete defaults)
- Add comprehensive test coverage for auto_cleanup_page behavior
- Update documentation in .env.example, README.md, and AGENTS.md